### PR TITLE
Feat/30 고정 질문 DB 구축 및 조회 기능

### DIFF
--- a/src/main/java/com/server/whaledone/config/response/exception/CustomExceptionStatus.java
+++ b/src/main/java/com/server/whaledone/config/response/exception/CustomExceptionStatus.java
@@ -44,7 +44,10 @@ public enum CustomExceptionStatus {
     REACTION_INVALID_REQUEST(true, "R002", "리액션 작성자가 아닙니다."),
 
     // Country
-    COUNTRY_NOT_EXISTS(true, "CO001", "해당 국가는 미지원하는 국가입니다.");
+    COUNTRY_NOT_EXISTS(true, "CO001", "해당 국가는 미지원하는 국가입니다."),
+
+    // Question
+    QUESTION_NOT_EXISTS_IN_CATEGORY(true, "Q001", "해당 카테고리의 질문이 존재하지 않습니다.");
 
     private final boolean responseStatus;
     private final String code;

--- a/src/main/java/com/server/whaledone/question/QuestionController.java
+++ b/src/main/java/com/server/whaledone/question/QuestionController.java
@@ -1,0 +1,33 @@
+package com.server.whaledone.question;
+
+import com.server.whaledone.config.response.ResponseService;
+import com.server.whaledone.config.response.result.CommonResult;
+import com.server.whaledone.config.response.result.MultipleResult;
+import com.server.whaledone.config.security.auth.CustomUserDetails;
+import com.server.whaledone.question.dto.QuestionResponseDto;
+import com.server.whaledone.reaction.dto.request.SaveReactionRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@Tag(name = "Question API")
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class QuestionController {
+
+    private final QuestionService questionService;
+    private final ResponseService responseService;
+
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
+    @Operation(summary = "질문 조회 API", description = "카테고리별로 랜덤한 질문을 리턴한다.")
+    @GetMapping("/questions/each-category/question")
+    public MultipleResult<QuestionResponseDto> getQuestionPerCategory(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return responseService.getMultipleResult(questionService.getQuestionsPerCategory());
+    }
+}

--- a/src/main/java/com/server/whaledone/question/QuestionController.java
+++ b/src/main/java/com/server/whaledone/question/QuestionController.java
@@ -26,7 +26,7 @@ public class QuestionController {
 
     @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
     @Operation(summary = "질문 조회 API", description = "카테고리별로 랜덤한 질문을 리턴한다.")
-    @GetMapping("/questions/each-category/question")
+    @GetMapping("/questions")
     public MultipleResult<QuestionResponseDto> getQuestionPerCategory(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return responseService.getMultipleResult(questionService.getQuestionsPerCategory());
     }

--- a/src/main/java/com/server/whaledone/question/QuestionRepository.java
+++ b/src/main/java/com/server/whaledone/question/QuestionRepository.java
@@ -1,0 +1,14 @@
+package com.server.whaledone.question;
+
+import com.server.whaledone.config.Entity.Status;
+import com.server.whaledone.question.entity.Question;
+import com.server.whaledone.question.entity.QuestionCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    Optional<List<Question>> findAllByCategoryAndStatus(QuestionCategory category, Status status);
+}

--- a/src/main/java/com/server/whaledone/question/QuestionService.java
+++ b/src/main/java/com/server/whaledone/question/QuestionService.java
@@ -1,0 +1,33 @@
+package com.server.whaledone.question;
+
+import com.server.whaledone.config.Entity.Status;
+import com.server.whaledone.config.response.exception.CustomException;
+import com.server.whaledone.config.response.exception.CustomExceptionStatus;
+import com.server.whaledone.question.dto.QuestionResponseDto;
+import com.server.whaledone.question.entity.Question;
+import com.server.whaledone.question.entity.QuestionCategory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+
+    private final QuestionRepository questionRepository;
+
+    public List<QuestionResponseDto> getQuestionsPerCategory() {
+        List<QuestionResponseDto> result = new ArrayList<>();
+        for (QuestionCategory category : QuestionCategory.values()) {
+            List<Question> questions = questionRepository.findAllByCategoryAndStatus(category, Status.ACTIVE)
+                    .orElseThrow(() -> new CustomException(CustomExceptionStatus.QUESTION_NOT_EXISTS_IN_CATEGORY));
+            Collections.shuffle(questions);
+            result.add(new QuestionResponseDto(questions.get(0)));
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/com/server/whaledone/question/dto/QuestionResponseDto.java
+++ b/src/main/java/com/server/whaledone/question/dto/QuestionResponseDto.java
@@ -1,0 +1,25 @@
+package com.server.whaledone.question.dto;
+
+import com.server.whaledone.question.entity.Question;
+import com.server.whaledone.question.entity.QuestionCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class QuestionResponseDto {
+
+    @Schema(name = "질문 카테고리")
+    private QuestionCategory category;
+
+    @Schema(name = "질문 내용")
+    private String content;
+
+    @Builder
+    public QuestionResponseDto(Question question) {
+        this.category = question.getCategory();
+        this.content = question.getContent();
+    }
+}

--- a/src/main/java/com/server/whaledone/question/entity/Question.java
+++ b/src/main/java/com/server/whaledone/question/entity/Question.java
@@ -1,0 +1,27 @@
+package com.server.whaledone.question.entity;
+
+import com.server.whaledone.config.Entity.Status;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class Question {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 500, nullable = false)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private QuestionCategory category;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+}

--- a/src/main/java/com/server/whaledone/question/entity/QuestionCategory.java
+++ b/src/main/java/com/server/whaledone/question/entity/QuestionCategory.java
@@ -1,0 +1,9 @@
+package com.server.whaledone.question.entity;
+
+public enum QuestionCategory {
+    WORK,
+    RELATIONSHIP,
+    DAILY,
+    HEALTH,
+    TMI
+}


### PR DESCRIPTION
카테고리별로 질문을 조회해서, 랜덤하게 뽑아서 리턴한다.
현재 카테고리별로 반복해서 총 5개의 select 쿼리가 나간다.

캐시를 이용해서 쿼리를 줄여보자.