### PR TITLE
Chore: 리눅스 환경변수 jasypt password 세팅

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source = /home/ec2-user/.bashrc
 REPOSITORY=/home/ec2-user/env/WhaleDone-Server
 CURRENT_PORT=$(cat /home/ec2-user/service_url.inc | grep -Po '[0-9]+' | tail -1)
 TARGET_PORT=0
@@ -20,6 +21,6 @@ if [ ! -z ${TARGET_PID} ]; then
   sudo kill ${TARGET_PID}
 fi
 
-nohup java -jar -Dserver.port=${TARGET_PORT} ${REPOSITORY}/build/libs/* > /home/ec2-user/env/nohup.out 2>&1 &
+nohup java -jar -Dserver.port=${TARGET_PORT} -DJASYPT_WHALEDONE_PASSWORD=${JASYPT_WHALEDONE_PASSWORD} ${REPOSITORY}/build/libs/* > /home/ec2-user/env/nohup.out 2>&1 &
 echo "> Now new WAS runs at ${TARGET_PORT}."
 exit 0

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source=/home/ec2-user/.bashrc
+source=/etc/profile.d/codedeploy.sh
 REPOSITORY=/home/ec2-user/env/WhaleDone-Server
 CURRENT_PORT=$(cat /home/ec2-user/service_url.inc | grep -Po '[0-9]+' | tail -1)
 TARGET_PORT=0

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source = /home/ec2-user/.bashrc
+source=/home/ec2-user/.bashrc
 REPOSITORY=/home/ec2-user/env/WhaleDone-Server
 CURRENT_PORT=$(cat /home/ec2-user/service_url.inc | grep -Po '[0-9]+' | tail -1)
 TARGET_PORT=0


### PR DESCRIPTION
CI/CD에서 jasypt password를 읽지 못해서 서버 run failed 발생

ec2의 ~/.bashrc에 변수로 세팅해둔다.

서버 내에 저장하고 변수를 읽으므로 외부에 노출되지 않는다.