### PR TITLE
Feat/42 메일을 이용해서 비밀번호 재발급, 변경기능

### DIFF
--- a/src/main/java/com/server/whaledone/certification/CertificationManager.java
+++ b/src/main/java/com/server/whaledone/certification/CertificationManager.java
@@ -84,7 +84,7 @@ public class CertificationManager {
     }
 
     // 유일한 코드 생성
-    private String randomGenerator(int countOfNumber) {
+    public String randomGenerator(int countOfNumber) {
         Random rnd = new Random();
         StringBuffer code = new StringBuffer();
 

--- a/src/main/java/com/server/whaledone/certification/entity/CustomCodeInfo.java
+++ b/src/main/java/com/server/whaledone/certification/entity/CustomCodeInfo.java
@@ -8,7 +8,7 @@ import java.util.Date;
 @Getter
 public abstract class CustomCodeInfo {
 
-    @Schema(name = "인증 만료 날짜")
+    @Schema(description = "인증 만료 날짜")
     private Date expiredTime;
 
     CustomCodeInfo(Date expiredTime) {

--- a/src/main/java/com/server/whaledone/certification/entity/InvitationCodeInfo.java
+++ b/src/main/java/com/server/whaledone/certification/entity/InvitationCodeInfo.java
@@ -9,7 +9,7 @@ import java.util.Date;
 @Getter
 public class InvitationCodeInfo extends CustomCodeInfo {
 
-    @Schema(name = "가족 id")
+    @Schema(description = "가족 id")
     private Long familyId;
 
     @Builder

--- a/src/main/java/com/server/whaledone/certification/entity/SmsCertificationCodeInfo.java
+++ b/src/main/java/com/server/whaledone/certification/entity/SmsCertificationCodeInfo.java
@@ -9,7 +9,7 @@ import java.util.Date;
 @Getter
 public class SmsCertificationCodeInfo extends CustomCodeInfo {
 
-    @Schema(name = "전화번호")
+    @Schema(description = "전화번호")
     private String phoneNumber;
 
     @Builder

--- a/src/main/java/com/server/whaledone/config/response/exception/CustomExceptionStatus.java
+++ b/src/main/java/com/server/whaledone/config/response/exception/CustomExceptionStatus.java
@@ -7,6 +7,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum CustomExceptionStatus {
 
+    // Server
+    INTERNAL_SERVER_ERROR(true, "SERVER001", "서버에 문제가 발생했어요. 잠시 후 다시 시도하세요."),
+    INVALID_AUTHORIZATION(true, "AUTH001", "해당 페이지에 권한이 없는 사용자입니다. 토큰을 확인해주세요."),
+    INVALID_AUTHENTICATION(true, "AUTH002", "클라이언트 인증이 실패한 사용자입니다."),
+
+
     // Common
     INVALID_INPUT_VALUE(true, "COM001", "유효하지 않은 입력입니다."),
 

--- a/src/main/java/com/server/whaledone/config/response/exception/ExceptionControllerAdvice.java
+++ b/src/main/java/com/server/whaledone/config/response/exception/ExceptionControllerAdvice.java
@@ -4,6 +4,8 @@ import com.server.whaledone.config.response.ResponseService;
 import com.server.whaledone.config.response.result.CommonResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.AuthorizationServiceException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -15,6 +17,12 @@ public class ExceptionControllerAdvice {
 
     private final ResponseService responseService;
 
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public CommonResult commonException(Exception exception) {
+        return responseService.getFailResult(CustomExceptionStatus.INTERNAL_SERVER_ERROR);
+    }
+
     @ExceptionHandler(CustomException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public CommonResult customException(CustomException customException) {
@@ -25,5 +33,11 @@ public class ExceptionControllerAdvice {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public CommonResult validationException(MethodArgumentNotValidException exception) {
         return responseService.getFailResult(CustomExceptionStatus.INVALID_INPUT_VALUE);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public CommonResult forBiddenException(AccessDeniedException exception) {
+        return responseService.getFailResult(CustomExceptionStatus.INVALID_AUTHORIZATION);
     }
 }

--- a/src/main/java/com/server/whaledone/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/whaledone/config/security/SecurityConfig.java
@@ -46,7 +46,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers(HttpMethod.POST, "/api/v1/user/sign-in", "/api/v1/user/sign-up",
                         "/api/v1/user/validation/email", "/api/v1/user/validation/nickname",
-                        "/api/v1/sms/code", "/api/v1/sms/validation/code").permitAll()
+                        "/api/v1/sms/code", "/api/v1/sms/validation/code",
+                        "/api/v1/user/new-password").permitAll()
                 .antMatchers("/api/v1/membership")
                 .access("hasRole('ROLE_MEMBERSHIP') or hasRole('ROLE_ADMIN')")
                 .anyRequest().authenticated();

--- a/src/main/java/com/server/whaledone/family/FamilyController.java
+++ b/src/main/java/com/server/whaledone/family/FamilyController.java
@@ -76,7 +76,7 @@ public class FamilyController {
     }
 
     @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
-    @Operation(summary = "해당 가족 채널에 있는 가족 구성원 조회 API",
+    @Operation(summary = "해당 채널의 가족 구성원 시차 조회 API",
             description = "갖고 있는 familyId를 통해 해당 가족 구성원의 시차를 조회한다.")
     @GetMapping("/families/{familyId}/users/time-difference")
     public MultipleResult<FamilyTimeDiffResponseDto> getFamilyTimeDiff(

--- a/src/main/java/com/server/whaledone/family/dto/request/UpdateFamilyNameRequestDto.java
+++ b/src/main/java/com/server/whaledone/family/dto/request/UpdateFamilyNameRequestDto.java
@@ -13,6 +13,6 @@ public class UpdateFamilyNameRequestDto {
 
     @NotBlank
     @Length(max = 10)
-    @Schema(name = "변경될 가족 채널 이름")
+    @Schema(description = "변경될 가족 채널 이름")
     private String updateName;
 }

--- a/src/main/java/com/server/whaledone/family/dto/request/ValidateInvitationCodeRequestDto.java
+++ b/src/main/java/com/server/whaledone/family/dto/request/ValidateInvitationCodeRequestDto.java
@@ -11,6 +11,6 @@ import javax.validation.constraints.NotBlank;
 public class ValidateInvitationCodeRequestDto {
 
     @NotBlank
-    @Schema(name = "초대 코드")
+    @Schema(description = "초대 코드")
     private String invitationCode;
 }

--- a/src/main/java/com/server/whaledone/family/dto/response/FamilyTimeDiffResponseDto.java
+++ b/src/main/java/com/server/whaledone/family/dto/response/FamilyTimeDiffResponseDto.java
@@ -10,13 +10,13 @@ import lombok.Getter;
 @AllArgsConstructor
 public class FamilyTimeDiffResponseDto {
 
-    @Schema(example = "유저 idx")
+    @Schema(description = "유저 idx")
     private Long id;
 
-    @Schema(example = "국가 코드")
+    @Schema(description = "국가 코드")
     private String countryCode;
 
-    @Schema(name = "한국 기준 시차")
+    @Schema(description = "한국 기준 시차")
     private String timeDiff;
 
     @Builder

--- a/src/main/java/com/server/whaledone/family/dto/response/ReIssueInvitationCodeResponseDto.java
+++ b/src/main/java/com/server/whaledone/family/dto/response/ReIssueInvitationCodeResponseDto.java
@@ -7,16 +7,16 @@ import lombok.Getter;
 @Getter
 public class ReIssueInvitationCodeResponseDto {
 
-    @Schema(name = "초대 코드")
+    @Schema(description = "초대 코드")
     String invitationCode;
     
-    @Schema(name = "남은 시간")
+    @Schema(description = "남은 시간")
     String hour;
 
-    @Schema(name = "남은 분")
+    @Schema(description = "남은 분", example = "mm")
     String minute;
 
-    @Schema(name = "남은 초")
+    @Schema(description = "남은 초", example = "ss")
     String second;
 
     @Builder

--- a/src/main/java/com/server/whaledone/family/dto/response/UsersInFamilyResponseDto.java
+++ b/src/main/java/com/server/whaledone/family/dto/response/UsersInFamilyResponseDto.java
@@ -13,28 +13,28 @@ import lombok.Setter;
 @Setter
 public class UsersInFamilyResponseDto {
 
-    @Schema(example = "유저 idx")
+    @Schema(description = "유저 idx")
     private Long id;
 
-    @Schema(example = "유저 닉네임")
+    @Schema(description = "유저 닉네임")
     private String nickName;
 
-    @Schema(example = "국가 코드")
+    @Schema(description = "국가 코드")
     private String countryCode;
 
-    @Schema(example = "국가 이름")
+    @Schema(description = "국가 이름")
     private String countryName;
 
-    @Schema(name = "위도")
+    @Schema(description = "위도")
     private Double latitude;
 
-    @Schema(name = "경도")
+    @Schema(description = "경도")
     private Double longitude;
 
-    @Schema(example = "유저 프로필 이미지 URL")
+    @Schema(description = "유저 프로필 이미지 URL")
     private String profileImgUrl;
 
-    @Schema(example = "나와 소통횟수 (나 자신은 0)")
+    @Schema(description = "나와 소통횟수 (나 자신은 0)")
     private Long communicationCount;
 
     @Builder

--- a/src/main/java/com/server/whaledone/mail/MailProvider.java
+++ b/src/main/java/com/server/whaledone/mail/MailProvider.java
@@ -1,0 +1,25 @@
+package com.server.whaledone.mail;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MailProvider {
+
+    private final JavaMailSender javaMailSender;
+
+    private static final String mailTitle = "[웨일던] 비밀번호 초기화 메일입니다.";
+
+    public void mailSend(MailRequestDto dto) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(dto.getAddress());
+        message.setSubject(mailTitle);
+        String tempPassword = dto.getMessage();
+        message.setText("임시 비밀번호 입니다 : " + tempPassword);
+
+        javaMailSender.send(message);
+    }
+}

--- a/src/main/java/com/server/whaledone/mail/MailProvider.java
+++ b/src/main/java/com/server/whaledone/mail/MailProvider.java
@@ -15,7 +15,7 @@ public class MailProvider {
 
     public void mailSend(MailRequestDto dto) {
         SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(dto.getAddress());
+        message.setTo(dto.getEmail());
         message.setSubject(mailTitle);
         String tempPassword = dto.getMessage();
         message.setText("임시 비밀번호 입니다 : " + tempPassword);

--- a/src/main/java/com/server/whaledone/mail/MailRequestDto.java
+++ b/src/main/java/com/server/whaledone/mail/MailRequestDto.java
@@ -10,14 +10,14 @@ import lombok.NoArgsConstructor;
 public class MailRequestDto {
 
     @Schema(description = "메일 받을 주소")
-    private String address;
+    private String email;
 
     @Schema(description = "메일 내용")
     private String message;
 
     @Builder
-    public MailRequestDto(String address, String message) {
-        this.address = address;
+    public MailRequestDto(String email, String message) {
+        this.email = email;
         this.message = message;
     }
 }

--- a/src/main/java/com/server/whaledone/mail/MailRequestDto.java
+++ b/src/main/java/com/server/whaledone/mail/MailRequestDto.java
@@ -1,0 +1,23 @@
+package com.server.whaledone.mail;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MailRequestDto {
+
+    @Schema(description = "메일 받을 주소")
+    private String address;
+
+    @Schema(description = "메일 내용")
+    private String message;
+
+    @Builder
+    public MailRequestDto(String address, String message) {
+        this.address = address;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/server/whaledone/posts/dto/ReactionCountDto.java
+++ b/src/main/java/com/server/whaledone/posts/dto/ReactionCountDto.java
@@ -10,10 +10,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ReactionCountDto {
 
-    @Schema(name = "리액션 type")
+    @Schema(description = "리액션 type", example = "TEXT, IMAGE, AUDIO")
     private ContentType type;
 
-    @Schema(name = "개수")
+    @Schema(description = "해당 리액션 개수")
     private Long count;
 
     @Builder

--- a/src/main/java/com/server/whaledone/posts/dto/SavePostsRequestDto.java
+++ b/src/main/java/com/server/whaledone/posts/dto/SavePostsRequestDto.java
@@ -14,14 +14,14 @@ import javax.validation.constraints.NotBlank;
 public class SavePostsRequestDto {
 
     @NotBlank
-    @Schema(name = "피드 제목")
+    @Schema(description = "피드 제목")
     private String title;
 
     @NotBlank
-    @Schema(name = "텍스트 내용 또는 URL")
+    @Schema(description = "텍스트 내용 또는 URL")
     private String content;
 
-    @Schema(name = "컨텐츠 유형 : 텍스트 = 0, 이미지 = 1, 오디오 = 2")
+    @Schema(description = "컨텐츠 유형", example = "TEXT, IMAGE, AUDIO")
     private ContentType type;
 
     @Builder

--- a/src/main/java/com/server/whaledone/posts/dto/UpdatePostsRequestDto.java
+++ b/src/main/java/com/server/whaledone/posts/dto/UpdatePostsRequestDto.java
@@ -11,13 +11,13 @@ import javax.validation.constraints.NotBlank;
 @NoArgsConstructor
 public class UpdatePostsRequestDto {
     @NotBlank
-    @Schema(name = "피드 제목")
+    @Schema(description = "피드 제목")
     private String title;
 
     @NotBlank
-    @Schema(name = "텍스트 내용 또는 URL")
+    @Schema(description = "텍스트 내용 또는 URL")
     private String content;
 
-    @Schema(name = "컨텐츠 유형 : 텍스트 = 0, 이미지 = 1, 오디오 = 2")
+    @Schema(description = "컨텐츠 유형", example = "TEXT, IMAGE, AUDIO")
     private ContentType type;
 }

--- a/src/main/java/com/server/whaledone/posts/dto/response/PostsResponseDto.java
+++ b/src/main/java/com/server/whaledone/posts/dto/response/PostsResponseDto.java
@@ -16,34 +16,34 @@ import java.util.List;
 @Data
 public class PostsResponseDto {
 
-    @Schema(name = "게시글 idx")
+    @Schema(description = "게시글 idx")
     Long id;
 
-    @Schema(name = "게시글 생성 날짜")
+    @Schema(description = "게시글 생성 날짜")
     LocalDate createdDate;
 
-    @Schema(name = "요일")
+    @Schema(description = "요일")
     DayOfWeek displayName;
 
-    @Schema(name = "글 작성자")
+    @Schema(description = "글 작성자")
     String authorName;
 
-    @Schema(name = "작성자 idx")
+    @Schema(description = "작성자 idx")
     Long authorIdx;
 
-    @Schema(name = "작성자 썸네일 URL")
+    @Schema(description = "작성자 썸네일 URL")
     String profileImgUrl;
 
-    @Schema(name = "게시글 제목")
+    @Schema(description = "게시글 제목")
     String title;
 
-    @Schema(name = "게시글 내용")
+    @Schema(description = "게시글 내용")
     String contents;
 
-    @Schema(name = "게시글 type")
+    @Schema(description = "게시글 type")
     ContentType type;
 
-    @Schema(name = "리액션 개수 리스트")
+    @Schema(description = "리액션 개수 리스트")
     List<ReactionCountDto> reactionCount = new ArrayList<>();
 
     // 리액션 리스트

--- a/src/main/java/com/server/whaledone/question/dto/QuestionResponseDto.java
+++ b/src/main/java/com/server/whaledone/question/dto/QuestionResponseDto.java
@@ -11,10 +11,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public class QuestionResponseDto {
 
-    @Schema(name = "질문 카테고리")
+    @Schema(description = "질문 카테고리")
     private QuestionCategory category;
 
-    @Schema(name = "질문 내용")
+    @Schema(description = "질문 내용")
     private String content;
 
     @Builder

--- a/src/main/java/com/server/whaledone/reaction/dto/request/ChangeReactionRequestDto.java
+++ b/src/main/java/com/server/whaledone/reaction/dto/request/ChangeReactionRequestDto.java
@@ -14,9 +14,9 @@ import javax.validation.constraints.NotBlank;
 public class ChangeReactionRequestDto {
 
     @NotBlank
-    @Schema(name = "리액션 내용 또는 URL")
+    @Schema(description = "리액션 내용 또는 URL")
     private String content;
 
-    @Schema(name = "컨텐츠 유형 : 텍스트 = 0, 이미지 = 1, 오디오 = 2")
+    @Schema(description = "컨텐츠 유형", example = "TEXT, IMAGE, AUDIO")
     private ContentType type;
 }

--- a/src/main/java/com/server/whaledone/reaction/dto/request/SaveReactionRequestDto.java
+++ b/src/main/java/com/server/whaledone/reaction/dto/request/SaveReactionRequestDto.java
@@ -14,10 +14,10 @@ import javax.validation.constraints.NotBlank;
 public class SaveReactionRequestDto {
 
     @NotBlank
-    @Schema(name = "리액션 내용 또는 URL")
+    @Schema(description = "리액션 내용 또는 URL")
     private String content;
 
-    @Schema(name = "컨텐츠 유형 : 텍스트 = 0, 이미지 = 1, 오디오 = 2")
+    @Schema(description = "컨텐츠 유형", example = "TEXT, IMAGE, AUDIO")
     private ContentType type;
 
     @Builder

--- a/src/main/java/com/server/whaledone/reaction/dto/response/GetReactionsResponseDto.java
+++ b/src/main/java/com/server/whaledone/reaction/dto/response/GetReactionsResponseDto.java
@@ -11,25 +11,25 @@ import java.time.LocalDateTime;
 @Data
 public class GetReactionsResponseDto {
 
-    @Schema(name = "리액션 idx")
+    @Schema(description = "리액션 idx")
     Long id;
 
-    @Schema(name = "리액션 생성 날짜")
+    @Schema(description = "리액션 생성 날짜")
     LocalDateTime createdDate;
 
-    @Schema(name = "리액션 작성자")
+    @Schema(description = "리액션 작성자")
     String authorName;
 
-    @Schema(name = "작성자 idx")
+    @Schema(description = "작성자 idx")
     Long authorIdx;
 
-    @Schema(name = "작성자 썸네일 URL")
+    @Schema(description = "작성자 썸네일 URL")
     String profileImgUrl;
 
-    @Schema(name = "리액션 내용 : text or URL")
+    @Schema(description = "리액션 내용", example = "text 또는 url")
     String contents;
 
-    @Schema(name = "리액션 type")
+    @Schema(description = "리액션 type", example = "TEXT, IMAGE, AUDIO")
     ContentType type;
 
     @Builder

--- a/src/main/java/com/server/whaledone/s3/PresignedUrlRequestDto.java
+++ b/src/main/java/com/server/whaledone/s3/PresignedUrlRequestDto.java
@@ -11,6 +11,6 @@ import javax.validation.constraints.NotBlank;
 public class PresignedUrlRequestDto {
 
     @NotBlank
-    @Schema(name = "파일 이름")
+    @Schema(description = "파일 이름")
     private String fileName;
 }

--- a/src/main/java/com/server/whaledone/s3/PresignedUrlResponseDto.java
+++ b/src/main/java/com/server/whaledone/s3/PresignedUrlResponseDto.java
@@ -8,6 +8,6 @@ import lombok.Data;
 @Builder
 public class PresignedUrlResponseDto {
 
-    @Schema(name = "presignedUrl")
+    @Schema(description = "presignedUrl")
     private String presignedUrl;
 }

--- a/src/main/java/com/server/whaledone/sms/SmsService.java
+++ b/src/main/java/com/server/whaledone/sms/SmsService.java
@@ -41,11 +41,15 @@ public class SmsService {
     private final ApplicationYmlConfig config;
     private final CertificationManager certificationManager;
 
+    private static final String smsMessage = " 웨일던에서 보내는 인증번호입니다. \n" +
+            "\n" +
+            "* 멀리 떨어진 가족의 일상과 마음을 공유하는 소통서비스, WhaleDone";
+
     public SmsResponseDto sendSms(SendSmsRequestDto dto) throws ParseException, JsonProcessingException, UnsupportedEncodingException, InvalidKeyException, NoSuchAlgorithmException, URISyntaxException, JsonProcessingException {
         Long time = System.currentTimeMillis();
         List<MessageDto> messages = new ArrayList<>(); // 보내는 사람에게 내용을 보냄.
         CustomCodeDto smsCodeDto = certificationManager.createSmsCode(dto.getRecipientPhoneNumber());
-        String content = "[웨일던] 인증번호 " + smsCodeDto.getCode();
+        String content = smsCodeDto.getCode() + smsMessage;
         messages.add(new MessageDto(dto.getRecipientPhoneNumber(),content)); // content부분이 내용임
 
         System.out.println("accessKey = " + config.getAccessKey());

--- a/src/main/java/com/server/whaledone/sms/dto/SendSmsRequestDto.java
+++ b/src/main/java/com/server/whaledone/sms/dto/SendSmsRequestDto.java
@@ -8,9 +8,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SendSmsRequestDto {
 
-    @Schema(name = "국가번호 : default = 82")
+    @Schema(description = "국가번호", example = "82")
     private String countryCode;
 
-    @Schema(name = "수신번호 : -를 제외한 숫자만 입력 가능")
+    @Schema(description = "수신번호", example = "01012345678 (- 제외)")
     private String recipientPhoneNumber;
 }

--- a/src/main/java/com/server/whaledone/sms/dto/ValidateSmsCodeRequestDto.java
+++ b/src/main/java/com/server/whaledone/sms/dto/ValidateSmsCodeRequestDto.java
@@ -10,10 +10,10 @@ import javax.validation.constraints.NotBlank;
 @NoArgsConstructor
 public class ValidateSmsCodeRequestDto {
     @NotBlank
-    @Schema(name = "인증 번호")
+    @Schema(description = "인증 번호", example = "5jdks")
     private String smsCode;
 
     @NotBlank
-    @Schema(name = "인증하는 회원 전화번호 ex) 01012345678")
+    @Schema(description = "인증하는 회원 전화번호", example = "01012345678")
     private String phoneNumber;
 }

--- a/src/main/java/com/server/whaledone/sms/dto/standard/SmsResponseDto.java
+++ b/src/main/java/com/server/whaledone/sms/dto/standard/SmsResponseDto.java
@@ -14,21 +14,21 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class SmsResponseDto {
 
-    @Schema(name = "요청 결과 ID")
+    @Schema(description = "요청 결과 ID", example = "1")
     private String requestId;
 
-    @Schema(name = "요청 시간")
+    @Schema(description = "요청 시간")
     private LocalDateTime requestTime;
 
-    @Schema(name = "상태 코드")
+    @Schema(description = "상태 코드")
     private String statusCode;
 
-    @Schema(name = "상태명")
+    @Schema(description = "상태명")
     private String statusName;
 
-    @Schema(name = "남은 유효시간 (mm)")
+    @Schema(description = "남은 유효시간", example = "mm")
     private String minute;
 
-    @Schema(name = "남은 유효시간 (ss)")
+    @Schema(description = "남은 유효시간", example = "ss")
     private String second;
 }

--- a/src/main/java/com/server/whaledone/user/UserController.java
+++ b/src/main/java/com/server/whaledone/user/UserController.java
@@ -92,4 +92,13 @@ public class UserController {
         userService.reIssuePassword(dto);
         return responseService.getSuccessResult();
     }
+
+    @Parameter(name = "X-AUTH-TOKEN", description = "로그인 성공 후 access_token", required = true)
+    @Operation(summary = "비밀번호 재설정 API", description = "임시 비밀번호 재발급 이후 비밀번호를 재설정한다.")
+    @PostMapping("/user/reset-password")
+    public CommonResult resetPassword(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                      @RequestBody @Valid ResetPasswordRequestDto dto) {
+        userService.resetPassword(userDetails, dto);
+        return responseService.getSuccessResult();
+    }
 }

--- a/src/main/java/com/server/whaledone/user/UserController.java
+++ b/src/main/java/com/server/whaledone/user/UserController.java
@@ -81,13 +81,15 @@ public class UserController {
             "채널 명만 바뀌어도 나머지 필드도 기존값과 함께 받는다.")
     @PatchMapping("/users/auth/information")
     public CommonResult updateUserInfo(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                               @RequestBody @Valid UpdateUserInfoRequestDto dto) {
+                                       @RequestBody @Valid UpdateUserInfoRequestDto dto) {
         userService.updateUserInfo(userDetails, dto);
         return responseService.getSuccessResult();
     }
 
-    @GetMapping("/test")
-    public String test() {
-        return "test";
+    @Operation(summary = "비밀번호 재발급 메일 API", description = "해당 API를 이용해서 메일로 임시 비밀번호를 유저에게 전송한다.")
+    @PostMapping("/user/new-password")
+    public CommonResult sendMail(@RequestBody @Valid ResetPasswordRequestDto dto) {
+        userService.resetPassword(dto);
+        return responseService.getSuccessResult();
     }
 }

--- a/src/main/java/com/server/whaledone/user/UserController.java
+++ b/src/main/java/com/server/whaledone/user/UserController.java
@@ -88,8 +88,8 @@ public class UserController {
 
     @Operation(summary = "비밀번호 재발급 메일 API", description = "해당 API를 이용해서 메일로 임시 비밀번호를 유저에게 전송한다.")
     @PostMapping("/user/new-password")
-    public CommonResult sendMail(@RequestBody @Valid ResetPasswordRequestDto dto) {
-        userService.resetPassword(dto);
+    public CommonResult sendReIssuePasswordMail(@RequestBody @Valid ReissuePasswordRequestDto dto) {
+        userService.reIssuePassword(dto);
         return responseService.getSuccessResult();
     }
 }

--- a/src/main/java/com/server/whaledone/user/UserService.java
+++ b/src/main/java/com/server/whaledone/user/UserService.java
@@ -126,4 +126,13 @@ public class UserService {
                 .message(tempPassword)
                 .build());
     }
+
+    @Transactional
+    public void resetPassword(CustomUserDetails userDetails, ResetPasswordRequestDto dto) {
+        User user = userRepository.findByEmailAndStatus(userDetails.getEmail(), userDetails.getStatus())
+                .orElseThrow(() -> new CustomException(CustomExceptionStatus.USER_NOT_EXISTS));
+
+        // 변경할 비밀번호를 받아서 reset
+        user.resetPassword(bCryptPasswordEncoder.encode(dto.getPassword()));
+    }
 }

--- a/src/main/java/com/server/whaledone/user/UserService.java
+++ b/src/main/java/com/server/whaledone/user/UserService.java
@@ -112,7 +112,7 @@ public class UserService {
     }
 
     @Transactional
-    public void resetPassword(ResetPasswordRequestDto dto) {
+    public void reIssuePassword(ReissuePasswordRequestDto dto) {
         // 비밀번호 재발급을 요청하는 유저의 이메일을 받아서, 유저 정보를 조회한다.
         User user = userRepository.findByEmailAndStatus(dto.getEmail(), Status.ACTIVE)
                 .orElseThrow(() -> new CustomException(CustomExceptionStatus.USER_NOT_EXISTS));

--- a/src/main/java/com/server/whaledone/user/dto/request/EmailValidRequestDto.java
+++ b/src/main/java/com/server/whaledone/user/dto/request/EmailValidRequestDto.java
@@ -13,6 +13,6 @@ public class EmailValidRequestDto {
 
     @Email
     @NotBlank
-    @Schema(example = "유저 이메일")
+    @Schema(description = "유저 이메일", example = "test@naver.com")
     private String email;
 }

--- a/src/main/java/com/server/whaledone/user/dto/request/ReissuePasswordRequestDto.java
+++ b/src/main/java/com/server/whaledone/user/dto/request/ReissuePasswordRequestDto.java
@@ -8,7 +8,7 @@ import javax.validation.constraints.Email;
 
 @Getter
 @NoArgsConstructor
-public class ResetPasswordRequestDto {
+public class ReissuePasswordRequestDto {
 
     @Email
     @Schema(description = "비밀번호 재발급 메일을 받을 유저 이메일", example = "test@naver.com")

--- a/src/main/java/com/server/whaledone/user/dto/request/ResetPasswordRequestDto.java
+++ b/src/main/java/com/server/whaledone/user/dto/request/ResetPasswordRequestDto.java
@@ -1,0 +1,17 @@
+package com.server.whaledone.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Email;
+
+@Getter
+@NoArgsConstructor
+public class ResetPasswordRequestDto {
+
+    @Email
+    @Schema(description = "비밀번호 재발급 메일을 받을 유저 이메일", example = "test@naver.com")
+    private String email;
+
+}

--- a/src/main/java/com/server/whaledone/user/dto/request/ResetPasswordRequestDto.java
+++ b/src/main/java/com/server/whaledone/user/dto/request/ResetPasswordRequestDto.java
@@ -1,0 +1,21 @@
+package com.server.whaledone.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@NoArgsConstructor
+public class ResetPasswordRequestDto {
+
+    @NotBlank
+    @Length(min = 8)
+    @Pattern(regexp = "^[0-9a-zA-Z]*$")
+    @Schema(description = "변경할 비밀번호")
+    private String password;
+}

--- a/src/main/java/com/server/whaledone/user/entity/User.java
+++ b/src/main/java/com/server/whaledone/user/entity/User.java
@@ -108,4 +108,8 @@ public class User extends BaseTimeEntity {
         reaction.assignAuthor(this);
         this.reactions.add(reaction);
     }
+
+    public void resetPassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,19 @@ spring:
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ENC(47+QKgqH4tEQEv+ksFCBTa9bLOE8m7Vych8ioXlYvHA=)
+    password: ENC(0FYTVKvrToK8gmcXEfBXhMga4ZLb8CaI)
+    protocol: smtp
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 springdoc:
   swagger-ui:
     operations-sorter: method


### PR DESCRIPTION
MailSender를 이용해서 비밀번호 재발급 및 초기화 기능 추가

- 비밀번호 찾기
문제점 : 메일 기반으로 userInfo를 조회하는데, 그러면 gmail로 가입한 사용자가 아니면 메일을 보낼 수 없다.
대안 : SMS으로 비밀번호를 재발급한다.

- 비밀번호 변경
추가할 것 : 현재 비밀번호까지 받아서 일치해야 비밀번호를 변경할 수 있도록.