### PR TITLE
Bugfix/48 게시글 날짜 내림차순 조회

### DIFF
--- a/src/main/java/com/server/whaledone/posts/PostsService.java
+++ b/src/main/java/com/server/whaledone/posts/PostsService.java
@@ -98,9 +98,16 @@ public class PostsService {
             }
         }
 
-        return result.stream().
-                sorted(Comparator.comparing(PostsResponseDto::getCreatedDate).reversed())
-                .collect(Collectors.groupingBy(PostsResponseDto::getCreatedDate));
+        TreeMap<LocalDate, List<PostsResponseDto>> collect = result.stream()
+                .collect(Collectors.groupingBy(PostsResponseDto::getCreatedDate, TreeMap::new, Collectors.toList()));
+
+        for (Map.Entry<LocalDate, List<PostsResponseDto>> localDateListEntry : collect.entrySet()) {
+            localDateListEntry.getValue().sort((o1, o2) -> o2.getId().compareTo(o1.getId()));
+        }
+
+        TreeMap<LocalDate, List<PostsResponseDto>> reverseResult = new TreeMap<>(Collections.reverseOrder());
+        reverseResult.putAll(collect);
+        return reverseResult;
     }
 
     private List<ReactionCountDto> getReactionCountListByType(List<Reaction> reactions) {

--- a/src/main/java/com/server/whaledone/reaction/ReactionService.java
+++ b/src/main/java/com/server/whaledone/reaction/ReactionService.java
@@ -103,7 +103,7 @@ public class ReactionService {
         return allReactions.stream()
                 .filter(reaction -> reaction.getStatus() == Status.ACTIVE)
                 .map(GetReactionAlarmsResponseDto::new)
-                .sorted(Comparator.comparing(GetReactionAlarmsResponseDto::getCreatedDate).reversed())
+                .sorted(Comparator.comparing(GetReactionAlarmsResponseDto::getReactionId).reversed())
                 .collect(Collectors.groupingBy(GetReactionAlarmsResponseDto::getCreatedDate));
     }
 }


### PR DESCRIPTION
게시글, 리액션 알람 조회 내림차순 조회

리액션은 id로 내림차순 정렬하면 map의 날짜까지 내림차순으로 매핑이 잘 되는데, 왜 게시글은 잘 안될까?