### PR TITLE
Bugfix/73 JWT 리팩토링

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -53,7 +53,7 @@ jobs:
       run: chmod +x gradlew
       
     - name: Build with Gradle
-      run: ./gradlew build -Pjasypt.encryptor.password=${{ secrets.JASYPT_WHALEDONE_PASSWORD }} -Pcloud.aws.credentials.access-key=${{ secrets.CREDENTIALS_ACCESS_KEY }} -Pcloud.aws.credentials.secret-key=${{ secrets.CREDENTIALS_SECRET_KEY }}
+      run: ./gradlew build -Pjasypt.encryptor.password=${{ secrets.JASYPT_WHALEDONE_PASSWORD }} -Pcloud.aws.credentials.access-key=${{ secrets.CREDENTIALS_ACCESS_KEY }} -Pcloud.aws.credentials.secret-key=${{ secrets.CREDENTIALS_SECRET_KEY }} -Pjwt.secret=${{ secrets.JWT_SECRET }}
 
     - name: Make zip file
       run: zip -r ./$GITHUB_SHA.zip .

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,7 +16,7 @@ on:
 env:
   S3_BUCKET_NAME: whaledone-server-dev
   PROJECT_NAME: WhaleDone-Server
-#  RESOURCE_PATH: ./src/main/resources/application.yml
+  RESOURCE_PATH: ./src/main/resources/application.yml
 
 jobs:
   build:
@@ -33,13 +33,15 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
 
-#    - name: Set yml file
-#      uses: microsoft/variable-substitution@v1
-#      with:
-#        files: ${{ env.RESOURCE_PATH }}
-#      env:
-#        cloud.aws.credentials.access-key: ${{ secrets.CREDENTIALS_ACCESS_KEY }}
-#        cloud.aws.credentials.secret-key: ${{ secrets.CREDENTIALS_SECRET_KEY }}
+    - name: Set yml file
+      uses: microsoft/variable-substitution@v1
+      with:
+        files: ${{ env.RESOURCE_PATH }}
+      env:
+        cloud.aws.credentials.access-key: ${{ secrets.CREDENTIALS_ACCESS_KEY }}
+        cloud.aws.credentials.secret-key: ${{ secrets.CREDENTIALS_SECRET_KEY }}
+        jasypt.encryptor.password: ${{ secrets.JASYPT_WHALEDONE_PASSWORD }}
+        jwt.secret: ${{ secrets.JWT_SECRET }}
 
     - name: Setup MySQL
       uses: samin/mysql-action@v1
@@ -53,7 +55,8 @@ jobs:
       run: chmod +x gradlew
       
     - name: Build with Gradle
-      run: ./gradlew build -Pjasypt.encryptor.password=${{ secrets.JASYPT_WHALEDONE_PASSWORD }} -Pcloud.aws.credentials.access-key=${{ secrets.CREDENTIALS_ACCESS_KEY }} -Pcloud.aws.credentials.secret-key=${{ secrets.CREDENTIALS_SECRET_KEY }} -Pjwt.secret=test
+      run: ./gradlew build
+      shell: bash
 
     - name: Make zip file
       run: zip -r ./$GITHUB_SHA.zip .

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,15 +33,15 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
 
-    - name: Set yml file
-      uses: microsoft/variable-substitution@v1
-      with:
-        files: ${{ env.RESOURCE_PATH }}
-      env:
-        cloud.aws.credentials.access-key: ${{ secrets.CREDENTIALS_ACCESS_KEY }}
-        cloud.aws.credentials.secret-key: ${{ secrets.CREDENTIALS_SECRET_KEY }}
-        jasypt.encryptor.password: ${{ secrets.JASYPT_WHALEDONE_PASSWORD }}
-        jwt.secret: ${{ secrets.JWT_SECRET }}
+#    - name: Set yml file
+#      uses: microsoft/variable-substitution@v1
+#      with:
+#        files: ${{ env.RESOURCE_PATH }}
+#      env:
+#        cloud.aws.credentials.access-key: ${{ secrets.CREDENTIALS_ACCESS_KEY }}
+#        cloud.aws.credentials.secret-key: ${{ secrets.CREDENTIALS_SECRET_KEY }}
+#        jasypt.encryptor.password: ${{ secrets.JASYPT_WHALEDONE_PASSWORD }}
+#        jwt.secret: ${{ secrets.JWT_SECRET }}
 
     - name: Setup MySQL
       uses: samin/mysql-action@v1
@@ -55,7 +55,7 @@ jobs:
       run: chmod +x gradlew
       
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build -Pcloud.aws.credentials.access-key=${{ secrets.CREDENTIALS_ACCESS_KEY }} -Pcloud.aws.credentials.secret-key=${{ secrets.CREDENTIALS_SECRET_KEY }} -Pjasypt.encryptor.password=${{ secrets.JASYPT_WHALEDONE_PASSWORD }} -Pjwt.secret=${{ secrets.JWT_SECRET }}
       shell: bash
 
     - name: Make zip file

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -53,7 +53,7 @@ jobs:
       run: chmod +x gradlew
       
     - name: Build with Gradle
-      run: ./gradlew build -Pjasypt.encryptor.password=${{ secrets.JASYPT_WHALEDONE_PASSWORD }} -Pcloud.aws.credentials.access-key=${{ secrets.CREDENTIALS_ACCESS_KEY }} -Pcloud.aws.credentials.secret-key=${{ secrets.CREDENTIALS_SECRET_KEY }} -Pjwt.secret=${{ secrets.JWT_SECRET }}
+      run: ./gradlew build -Pjasypt.encryptor.password=${{ secrets.JASYPT_WHALEDONE_PASSWORD }} -Pcloud.aws.credentials.access-key=${{ secrets.CREDENTIALS_ACCESS_KEY }} -Pcloud.aws.credentials.secret-key=${{ secrets.CREDENTIALS_SECRET_KEY }} -Pjwt.secret=test
 
     - name: Make zip file
       run: zip -r ./$GITHUB_SHA.zip .

--- a/src/main/java/com/server/whaledone/config/response/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/server/whaledone/config/response/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,29 @@
+package com.server.whaledone.config.response.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        CustomExceptionStatus exception = (CustomExceptionStatus) request.getAttribute("tokenException");
+        log.error("Authentication Exception at AuthenticationEntryPoint");
+
+        if (exception == null || exception.equals(CustomExceptionStatus.INVALID_TOKEN)){
+            response.sendRedirect("/exception/invalid-token"); // AlgorithmMismatchException, InvalidClaimException, NullPointerException
+        } else if (exception.equals(CustomExceptionStatus.TOKEN_EXPIRED)) {
+            response.sendRedirect("/exception/expired-token"); // TokenExpiredException
+        } else if (exception.equals(CustomExceptionStatus.INVALID_AUTHENTICATION)) {
+            response.sendRedirect(("/exception/jwt"));// JWTVerificationException
+        }
+    }
+}

--- a/src/main/java/com/server/whaledone/config/response/exception/CustomExceptionStatus.java
+++ b/src/main/java/com/server/whaledone/config/response/exception/CustomExceptionStatus.java
@@ -9,8 +9,12 @@ public enum CustomExceptionStatus {
 
     // Server
     INTERNAL_SERVER_ERROR(true, "SERVER001", "서버에 문제가 발생했어요. 잠시 후 다시 시도하세요."),
-    INVALID_AUTHORIZATION(true, "AUTH001", "해당 페이지에 권한이 없는 사용자입니다. 토큰을 확인해주세요."),
+
+    // Authentication, Authorization with token
+    INVALID_AUTHORIZATION(true, "AUTH001", "해당 페이지에 권한이 없는 사용자입니다."),
     INVALID_AUTHENTICATION(true, "AUTH002", "클라이언트 인증이 실패한 사용자입니다."),
+    TOKEN_EXPIRED(true, "AUTHO003", "로그인이 만료되었습니다."),
+    INVALID_TOKEN(true, "AUTHO004", "유효하지 않은 인증 정보입니다."),
 
 
     // Common

--- a/src/main/java/com/server/whaledone/config/response/exception/ExceptionController.java
+++ b/src/main/java/com/server/whaledone/config/response/exception/ExceptionController.java
@@ -1,0 +1,27 @@
+package com.server.whaledone.config.response.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/exception")
+public class ExceptionController {
+
+    @GetMapping("/expired-token")
+    public void getExpiredTokenException() {
+        throw new CustomException(CustomExceptionStatus.TOKEN_EXPIRED);
+    }
+
+    @GetMapping("/invalid-token")
+    public void getInvalidTokenException() {
+        throw new CustomException(CustomExceptionStatus.INVALID_TOKEN);
+    }
+
+    @GetMapping("/jwt")
+    public void getJwtException() {
+        throw new CustomException(CustomExceptionStatus.INVALID_AUTHENTICATION);
+    }
+}

--- a/src/main/java/com/server/whaledone/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/whaledone/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.server.whaledone.config.security;
 
+import com.server.whaledone.config.response.exception.CustomAuthenticationEntryPoint;
 import com.server.whaledone.config.security.jwt.JwtAuthenticationFilter;
 import com.server.whaledone.config.security.jwt.JwtTokenProvider;
 import com.server.whaledone.user.UserRepository;
@@ -51,11 +52,16 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .addFilter(corsFilter)
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
 
+                .exceptionHandling()
+                .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                .and()
+
                 .authorizeRequests()
                 .antMatchers(HttpMethod.POST, "/api/v1/user/sign-in", "/api/v1/user/sign-up",
                         "/api/v1/user/validation/email", "/api/v1/user/validation/nickname",
                         "/api/v1/sms/code", "/api/v1/sms/validation/code",
                         "/api/v1/user/new-password").permitAll()
+                .antMatchers(HttpMethod.GET, "/exception/**").permitAll()
                 .antMatchers("/api/v1/membership")
                 .access("hasRole('ROLE_MEMBERSHIP') or hasRole('ROLE_ADMIN')")
                 .anyRequest().authenticated();

--- a/src/main/java/com/server/whaledone/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/server/whaledone/config/security/jwt/JwtAuthenticationFilter.java
@@ -20,7 +20,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
-        if (token != null && jwtTokenProvider.validateToken(token, request)) {
+        if (jwtTokenProvider.validateToken(token, request)) {
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/main/java/com/server/whaledone/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/server/whaledone/config/security/jwt/JwtAuthenticationFilter.java
@@ -20,7 +20,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
-        if (token != null && jwtTokenProvider.validateToken(token)) {
+        if (token != null && jwtTokenProvider.validateToken(token, request)) {
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }

--- a/src/main/java/com/server/whaledone/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/server/whaledone/config/security/jwt/JwtTokenProvider.java
@@ -40,7 +40,7 @@ public class JwtTokenProvider {
                 .withExpiresAt(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
                 .withClaim("role", roleType.toString())
                 .withClaim("email", email)
-                .sign(Algorithm.HMAC512(SECRET_KEY));
+                .sign(Algorithm.HMAC256(SECRET_KEY));
     }
 
     // jwt 토큰에서 인증 정보 조회

--- a/src/main/java/com/server/whaledone/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/server/whaledone/config/security/jwt/JwtTokenProvider.java
@@ -8,7 +8,6 @@ import com.auth0.jwt.exceptions.InvalidClaimException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import com.server.whaledone.config.Entity.Status;
 import com.server.whaledone.config.response.exception.CustomExceptionStatus;
 import com.server.whaledone.config.security.auth.CustomUserDetailsService;
 import com.server.whaledone.user.entity.RoleType;
@@ -82,17 +81,13 @@ public class JwtTokenProvider {
         }
         try {
             final JWTVerifier jwtVerifier = JWT.require(Algorithm.HMAC256(SECRET_KEY)).build();
-
             DecodedJWT decodedJWT = jwtVerifier.verify(token);
             return true;
         } catch (TokenExpiredException tokenExpiredException) {
-            request.setAttribute("exceptionMessage", tokenExpiredException.getMessage());
             request.setAttribute("tokenException", CustomExceptionStatus.TOKEN_EXPIRED);
         } catch (AlgorithmMismatchException | InvalidClaimException invalidTokenException) {
-            request.setAttribute("exceptionMessage", invalidTokenException.getMessage());
             request.setAttribute("tokenException", CustomExceptionStatus.INVALID_TOKEN);
         } catch (JWTVerificationException exception) {
-            request.setAttribute("exceptionMessage", exception.getMessage());
             request.setAttribute("tokenException", CustomExceptionStatus.INVALID_AUTHENTICATION);
         }
         return false;

--- a/src/main/java/com/server/whaledone/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/server/whaledone/config/security/jwt/JwtTokenProvider.java
@@ -30,8 +30,9 @@ import java.util.Date;
 @Slf4j
 public class JwtTokenProvider {
 
-    @Value("${jwt.secret}")
-    private String SECRET_KEY;
+//    @Value("${jwt.secret}")
+//    private String SECRET_KEY;
+    private String SECRET_KEY = "test";
     private long EXPIRATION_TIME = 100 * 24 * 60 * 60 * 1000L;
     private String HEADER_STRING = "X-AUTH-TOKEN";
     private String TOKEN_PREFIX = "Bearer ";

--- a/src/main/java/com/server/whaledone/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/server/whaledone/config/security/jwt/JwtTokenProvider.java
@@ -77,6 +77,9 @@ public class JwtTokenProvider {
 
     // 토큰의 유효성 + 만료일자 확인
     public boolean validateToken(String token, ServletRequest request) {
+        if (token == null) {
+            return false;
+        }
         try {
             final JWTVerifier jwtVerifier = JWT.require(Algorithm.HMAC256(SECRET_KEY)).build();
 

--- a/src/main/java/com/server/whaledone/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/server/whaledone/config/security/jwt/JwtTokenProvider.java
@@ -30,9 +30,8 @@ import java.util.Date;
 @Slf4j
 public class JwtTokenProvider {
 
-//    @Value("${jwt.secret}")
-//    private String SECRET_KEY;
-    private String SECRET_KEY = "test";
+    @Value("${jwt.secret}")
+    private String SECRET_KEY;
     private long EXPIRATION_TIME = 100 * 24 * 60 * 60 * 1000L;
     private String HEADER_STRING = "X-AUTH-TOKEN";
     private String TOKEN_PREFIX = "Bearer ";

--- a/src/main/java/com/server/whaledone/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/server/whaledone/config/security/jwt/JwtTokenProvider.java
@@ -5,25 +5,33 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.server.whaledone.config.security.auth.CustomUserDetailsService;
 import com.server.whaledone.user.entity.RoleType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
+import java.util.Base64;
 import java.util.Date;
 
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
-    private long EXPIRATION_TIME = 1000L * 60 * 60 * 10 * 24 * 10; // 10일 (1/1000초)
-    private String SECRET_KEY = "temp";
+    @Value("${jwt.secret}")
+    private String SECRET_KEY;
+    private long EXPIRATION_TIME = 100 * 24 * 60 * 60 * 1000L;
     private String HEADER_STRING = "X-AUTH-TOKEN";
     private String TOKEN_PREFIX = "Bearer ";
 
     private final CustomUserDetailsService customUserDetailsService;
 
+    @PostConstruct
+    private void init() {
+        SECRET_KEY = Base64.getEncoder().encodeToString(SECRET_KEY.getBytes());
+    }
 
     // jwt 토큰 생성
     public String createToken(String email, RoleType roleType) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,7 +69,7 @@ firebase:
   apiUrl: https://fcm.googleapis.com/v1/projects/whaledone-29e55/messages:send
 
 jwt:
-  secret: ${JWT_SECRET}
+  secret: test
 ---
 spring:
   config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,6 +67,9 @@ sms:
 firebase:
   key: firebase/whaledone-firebase-key.json
   apiUrl: https://fcm.googleapis.com/v1/projects/whaledone-29e55/messages:send
+
+jwt:
+  secret: ${JWT_SECRET}
 ---
 spring:
   config:


### PR DESCRIPTION
기존에 제대로 동작하지 않던 JWT 로직을 변경

1. 토큰 생성에 사용되는 secret key가 그대로 노출되어 있던 것을 설정 파일로 변경
2. validateToken에서 토큰 검증이 이루어지지 않던 로직을 수정
- JWTVerifier를 통해서 헤더, 페이로드, 시그니쳐 검증
- 각 예외 케이스(알고리즘 오류, JWT 내용 불일치, 유효기간 만료 등) 에 따라서 예외처리 추가