### PR TITLE
Feat/82 임시 비밀번호 인증 API 추가

### DIFF
--- a/src/main/java/com/server/whaledone/config/response/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/server/whaledone/config/response/exception/CustomAuthenticationEntryPoint.java
@@ -16,7 +16,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         CustomExceptionStatus exception = (CustomExceptionStatus) request.getAttribute("tokenException");
-        log.error("Authentication Exception at AuthenticationEntryPoint : {}", request.getRemoteAddr());
+        log.warn("Authentication Exception at AuthenticationEntryPoint - ip : {} | URL : {}", request.getRemoteAddr(), request.getRequestURL());
         if (exception == null || exception.equals(CustomExceptionStatus.INVALID_TOKEN)){
             response.sendRedirect("/exception/invalid-token"); // AlgorithmMismatchException, InvalidClaimException, NullPointerException
         } else if (exception.equals(CustomExceptionStatus.TOKEN_EXPIRED)) {

--- a/src/main/java/com/server/whaledone/config/response/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/server/whaledone/config/response/exception/CustomAuthenticationEntryPoint.java
@@ -16,8 +16,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         CustomExceptionStatus exception = (CustomExceptionStatus) request.getAttribute("tokenException");
-        log.error("Authentication Exception at AuthenticationEntryPoint");
-
+        log.error("Authentication Exception at AuthenticationEntryPoint : {}", request.getRemoteAddr());
         if (exception == null || exception.equals(CustomExceptionStatus.INVALID_TOKEN)){
             response.sendRedirect("/exception/invalid-token"); // AlgorithmMismatchException, InvalidClaimException, NullPointerException
         } else if (exception.equals(CustomExceptionStatus.TOKEN_EXPIRED)) {

--- a/src/main/java/com/server/whaledone/config/security/SecurityConfig.java
+++ b/src/main/java/com/server/whaledone/config/security/SecurityConfig.java
@@ -60,7 +60,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.POST, "/api/v1/user/sign-in", "/api/v1/user/sign-up",
                         "/api/v1/user/validation/email", "/api/v1/user/validation/nickname",
                         "/api/v1/sms/code", "/api/v1/sms/validation/code",
-                        "/api/v1/user/new-password").permitAll()
+                        "/api/v1/user/new-password", "/api/v1/user/validation/password-code").permitAll()
                 .antMatchers(HttpMethod.GET, "/exception/**").permitAll()
                 .antMatchers("/api/v1/membership")
                 .access("hasRole('ROLE_MEMBERSHIP') or hasRole('ROLE_ADMIN')")

--- a/src/main/java/com/server/whaledone/user/UserController.java
+++ b/src/main/java/com/server/whaledone/user/UserController.java
@@ -6,6 +6,7 @@ import com.server.whaledone.config.response.result.CommonResult;
 import com.server.whaledone.config.response.result.SingleResult;
 import com.server.whaledone.config.security.auth.CustomUserDetails;
 import com.server.whaledone.sms.dto.SendSmsRequestDto;
+import com.server.whaledone.sms.dto.ValidateSmsCodeRequestDto;
 import com.server.whaledone.user.dto.request.*;
 import com.server.whaledone.user.dto.response.SignInResponseDto;
 import com.server.whaledone.user.dto.response.SignUpResponseDto;
@@ -107,5 +108,11 @@ public class UserController {
                                       @RequestBody @Valid ResetPasswordRequestDto dto) {
         userService.resetPassword(userDetails, dto);
         return responseService.getSuccessResult();
+    }
+
+    @Operation(summary = "비밀번호 초기화 인증 번호 검증 API", description = "인증 번호를 입력 받아 본인 인증을 진행 후 임시 비밀번호를 발급한다.")
+    @PostMapping("/user/validation/password-code")
+    public CommonResult validatePasswordCode(@RequestBody @Valid ValidateSmsCodeRequestDto dto) {
+        return responseService.getSingleResult(userService.validatePasswordCode(dto));
     }
 }

--- a/src/main/java/com/server/whaledone/user/dto/response/ResetPasswordResponseDto.java
+++ b/src/main/java/com/server/whaledone/user/dto/response/ResetPasswordResponseDto.java
@@ -1,0 +1,13 @@
+package com.server.whaledone.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ResetPasswordResponseDto {
+
+    @Schema(description = "임시 비밀번호")
+    private String tempPassword;
+}


### PR DESCRIPTION
1. 본인 인증 API (문자로 인증코드 전달)
2. 해당 인증 코드를 새로운 API에 전달
3. 일치하면 임시 비밀번호 응답

이후 클라이언트는 해당 비밀번호로 로그인 후 비밀번호 재설정
