### PR TITLE
Bugfix: HashMap -> WeakHashMap으로 변경

### DIFF
--- a/src/main/java/com/server/whaledone/certification/CertificationManager.java
+++ b/src/main/java/com/server/whaledone/certification/CertificationManager.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Date;
 import java.util.Random;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.WeakHashMap;
 
 @Component
 public class CertificationManager {
@@ -21,7 +21,7 @@ public class CertificationManager {
     private final long SMS_CERTIFICATION_CODE_EXPIRATION_TIME = 3 * 60 * 1000L; // 1초 * 60(초) * 3(분) = 3분
     private final long GROUP_INVITATION_CODE_EXPIRATION_TIME = 48 * 60 * 60 * 1000L; // 1초 * 60(초) * 60(분) * 48(시간) = 48시간
 
-    private ConcurrentHashMap<String, CustomCodeInfo> codeRepository = new ConcurrentHashMap<>();
+    private WeakHashMap<String, CustomCodeInfo> codeRepository = new WeakHashMap<>();
     // SMS -> key : 인증코드, value : 전화번호 & expiredAt
     // Invitation -> key : 인증코드, value : familyId & expiredAt
 


### PR DESCRIPTION
<h1> 이슈 내용 </h1>

- 임시 정보를 HashMap으로 관리할 경우, 해당 Entry는 사라지지 않고 계속 메모리를 차지하고 있음

<h1> To-do </h1>

- [x] GC의 대상이 되도록 WeakHashMap으로 변경

<h1> 참고 사항 </h1>

- 추후 Redis를 통해 로컬 캐시로 변경하기
